### PR TITLE
Add gender and age selection flow with updated dark theme

### DIFF
--- a/lib/age_selection_page.dart
+++ b/lib/age_selection_page.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class AgeSelectionPage extends StatefulWidget {
+  final String selectedGender;
+  const AgeSelectionPage({super.key, required this.selectedGender});
+
+  @override
+  State<AgeSelectionPage> createState() => _AgeSelectionPageState();
+}
+
+class _AgeSelectionPageState extends State<AgeSelectionPage> {
+  double _currentAge = 18;
+
+  void _continue() {
+    final age = _currentAge.round();
+    debugPrint('Gender: ${widget.selectedGender}, Age: $age');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text(
+                'Select your age',
+                style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 32),
+              Text(
+                '${_currentAge.round()}',
+                style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+              ),
+              Slider(
+                value: _currentAge,
+                min: 18,
+                max: 80,
+                divisions: 62,
+                label: _currentAge.round().toString(),
+                onChanged: (value) => setState(() => _currentAge = value),
+                activeColor: Colors.white,
+                inactiveColor: Colors.white24,
+              ),
+              const SizedBox(height: 32),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _continue,
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    backgroundColor: const Color(0xFF001F54),
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text(
+                    'Continue',
+                    style: TextStyle(fontSize: 18),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/gender_selection_page.dart
+++ b/lib/gender_selection_page.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'age_selection_page.dart';
+
+class GenderSelectionPage extends StatefulWidget {
+  const GenderSelectionPage({super.key});
+
+  @override
+  State<GenderSelectionPage> createState() => _GenderSelectionPageState();
+}
+
+class _GenderSelectionPageState extends State<GenderSelectionPage> {
+  String _selectedGender = '';
+
+  void _selectGender(String gender) {
+    _selectedGender = gender;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => AgeSelectionPage(selectedGender: _selectedGender),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text(
+                'Who are you?',
+                style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 32),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () => _selectGender("male"),
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 24),
+                    backgroundColor: const Color(0xFF001F54),
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text(
+                    "I'm a man \u{1F468}",
+                    style: TextStyle(fontSize: 18),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () => _selectGender("female"),
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 24),
+                    backgroundColor: const Color(0xFF001F54),
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text(
+                    "I'm a woman \u{1F469}",
+                    style: TextStyle(fontSize: 18),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'login_page.dart';
+import 'gender_selection_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -13,7 +13,25 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Reduce Smoking App',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        scaffoldBackgroundColor: const Color(0xFF001F54),
+        textTheme: ThemeData.light().textTheme.apply(
+              bodyColor: Colors.white,
+              displayColor: Colors.white,
+            ),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFF001F54),
+          brightness: Brightness.dark,
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: const Color(0xFF001F54),
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 24),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+        ),
       ),
       home: const TermsPage(),
     );
@@ -30,9 +48,9 @@ class TermsPage extends StatefulWidget {
 class _TermsPageState extends State<TermsPage> {
   bool _agreed = false;
 
-  void _goToLogin() {
+  void _goToGenderSelection() {
     Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => const LoginPage()),
+      MaterialPageRoute(builder: (_) => const GenderSelectionPage()),
     );
   }
 
@@ -64,9 +82,12 @@ class _TermsPageState extends State<TermsPage> {
                   controlAffinity: ListTileControlAffinity.leading,
                 ),
                 const SizedBox(height: 16),
-                ElevatedButton(
-                  onPressed: _agreed ? _goToLogin : null,
-                  child: const Text('Continue'),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: _agreed ? _goToGenderSelection : null,
+                    child: const Text('Continue'),
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- apply dark blue theme with white text and rounded buttons
- route Terms page to gender and age selection pages
- implement gender and age selection pages with console logging

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fb72acf548331b18beda9d440001d