### PR TITLE
Add login page after terms

### DIFF
--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -1,14 +1,41 @@
 import 'package:flutter/material.dart';
+import 'gender_selection_page.dart';
 
 class LoginPage extends StatelessWidget {
   const LoginPage({super.key});
 
+  void _goToGenderSelection(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const GenderSelectionPage()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Login / Create Account')),
-      body: const Center(
-        child: Text('Login / Create Account Page'),
+      appBar: AppBar(title: const Text('Login or Create Account')),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () => _goToGenderSelection(context),
+                child: const Text('Create Account'),
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () => _goToGenderSelection(context),
+                child: const Text('Log In'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'gender_selection_page.dart';
+import 'login_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -48,9 +48,9 @@ class TermsPage extends StatefulWidget {
 class _TermsPageState extends State<TermsPage> {
   bool _agreed = false;
 
-  void _goToGenderSelection() {
+  void _goToLogin() {
     Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => const GenderSelectionPage()),
+      MaterialPageRoute(builder: (_) => const LoginPage()),
     );
   }
 
@@ -85,7 +85,7 @@ class _TermsPageState extends State<TermsPage> {
                 SizedBox(
                   width: double.infinity,
                   child: ElevatedButton(
-                    onPressed: _agreed ? _goToGenderSelection : null,
+                    onPressed: _agreed ? _goToLogin : null,
                     child: const Text('Continue'),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- Navigate from terms acceptance to new login/create account screen
- Provide login page with create account and log in options

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/*.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbfac1c14833184e45a1a15d52a1f