### PR TITLE
Add login and account creation flow

### DIFF
--- a/lib/auth_choice_page.dart
+++ b/lib/auth_choice_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'login_page.dart';
+import 'terms_page.dart';
+
+class AuthChoicePage extends StatelessWidget {
+  const AuthChoicePage({super.key});
+
+  void _goToCreate(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const TermsPage()),
+    );
+  }
+
+  void _goToLogin(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const LoginPage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Welcome')),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () => _goToCreate(context),
+                child: const Text('Create Account'),
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () => _goToLogin(context),
+                child: const Text('Log In'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/create_account_page.dart
+++ b/lib/create_account_page.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+class CreateAccountPage extends StatefulWidget {
+  const CreateAccountPage({super.key});
+
+  @override
+  State<CreateAccountPage> createState() => _CreateAccountPageState();
+}
+
+class _CreateAccountPageState extends State<CreateAccountPage> {
+  final _formKey = GlobalKey<FormState>();
+  String? _gender;
+  final _ageController = TextEditingController();
+  final _countryController = TextEditingController();
+  final _cigarettesController = TextEditingController();
+  final _sinceController = TextEditingController();
+  final _messageController = TextEditingController();
+
+  @override
+  void dispose() {
+    _ageController.dispose();
+    _countryController.dispose();
+    _cigarettesController.dispose();
+    _sinceController.dispose();
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      debugPrint('Gender: $_gender, Age: ${_ageController.text}, Country: ${_countryController.text}, Cigarettes: ${_cigarettesController.text}, Since: ${_sinceController.text}, Message: ${_messageController.text}');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Account')),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              DropdownButtonFormField<String>(
+                value: _gender,
+                decoration: const InputDecoration(labelText: 'Gender'),
+                items: const [
+                  DropdownMenuItem(value: 'Male', child: Text('Male')),
+                  DropdownMenuItem(value: 'Female', child: Text('Female')),
+                  DropdownMenuItem(value: 'Other', child: Text('Other')),
+                ],
+                onChanged: (value) => setState(() => _gender = value),
+                validator: (value) => value == null ? 'Please select your gender' : null,
+              ),
+              TextFormField(
+                controller: _ageController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: 'Age'),
+                validator: (value) => value == null || value.isEmpty ? 'Enter your age' : null,
+              ),
+              TextFormField(
+                controller: _countryController,
+                decoration: const InputDecoration(labelText: 'Country'),
+                validator: (value) => value == null || value.isEmpty ? 'Enter your country' : null,
+              ),
+              TextFormField(
+                controller: _cigarettesController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: 'Cigarettes per day'),
+                validator: (value) => value == null || value.isEmpty ? 'Enter number of cigarettes' : null,
+              ),
+              TextFormField(
+                controller: _sinceController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: 'Since when you smoke (year)'),
+                validator: (value) => value == null || value.isEmpty ? 'Enter year' : null,
+              ),
+              TextFormField(
+                controller: _messageController,
+                decoration: const InputDecoration(labelText: 'Tell us about your smoking habits'),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _submit,
+                  child: const Text('Submit'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -1,38 +1,37 @@
 import 'package:flutter/material.dart';
-import 'gender_selection_page.dart';
 
 class LoginPage extends StatelessWidget {
   const LoginPage({super.key});
 
-  void _goToGenderSelection(BuildContext context) {
-    Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => const GenderSelectionPage()),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Login or Create Account')),
+      appBar: AppBar(title: const Text('Log In')),
       body: Padding(
         padding: const EdgeInsets.all(24.0),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () => _goToGenderSelection(context),
-                child: const Text('Create Account'),
+            const TextField(
+              decoration: InputDecoration(labelText: 'Username'),
+            ),
+            const SizedBox(height: 16),
+            const TextField(
+              decoration: InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () {},
+                child: const Text('Forgot password?'),
               ),
             ),
             const SizedBox(height: 16),
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () => _goToGenderSelection(context),
-                child: const Text('Log In'),
-              ),
+            ElevatedButton(
+              onPressed: () {},
+              child: const Text('Log In'),
             ),
           ],
         ),
@@ -40,3 +39,4 @@ class LoginPage extends StatelessWidget {
     );
   }
 }
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'login_page.dart';
+import 'auth_choice_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -33,67 +33,8 @@ class MyApp extends StatelessWidget {
           ),
         ),
       ),
-      home: const TermsPage(),
+      home: const AuthChoicePage(),
     );
   }
 }
 
-class TermsPage extends StatefulWidget {
-  const TermsPage({super.key});
-
-  @override
-  State<TermsPage> createState() => _TermsPageState();
-}
-
-class _TermsPageState extends State<TermsPage> {
-  bool _agreed = false;
-
-  void _goToLogin() {
-    Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => const LoginPage()),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Text(
-                  'Terms and Conditions',
-                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 16),
-                const Text(
-                  'Placeholder terms and conditions go here. Please read them carefully before continuing.',
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 24),
-                CheckboxListTile(
-                  value: _agreed,
-                  onChanged: (value) => setState(() => _agreed = value ?? false),
-                  title: const Text('I agree to the terms and conditions'),
-                  controlAffinity: ListTileControlAffinity.leading,
-                ),
-                const SizedBox(height: 16),
-                SizedBox(
-                  width: double.infinity,
-                  child: ElevatedButton(
-                    onPressed: _agreed ? _goToLogin : null,
-                    child: const Text('Continue'),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}

--- a/lib/terms_page.dart
+++ b/lib/terms_page.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'create_account_page.dart';
+
+class TermsPage extends StatefulWidget {
+  const TermsPage({super.key});
+
+  @override
+  State<TermsPage> createState() => _TermsPageState();
+}
+
+class _TermsPageState extends State<TermsPage> {
+  bool _agreed = false;
+
+  void _continue() {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const CreateAccountPage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'Terms and Conditions',
+                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  'Placeholder terms and conditions go here. Please read them carefully before continuing.',
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                CheckboxListTile(
+                  value: _agreed,
+                  onChanged: (value) => setState(() => _agreed = value ?? false),
+                  title: const Text('I agree to the terms and conditions'),
+                  controlAffinity: ListTileControlAffinity.leading,
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: _agreed ? _continue : null,
+                    child: const Text('Continue'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Replace initial terms screen with a landing page offering login or account creation
- Add login form with username/password and forgot-password link
- Add create-account flow that shows terms and collects gender, age, country, cigarette usage and a message

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688fc33972388331ad86de3bb14849e8