### PR TITLE
Fix Android build config for Java 8 desugaring

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,11 +8,12 @@ plugins {
 android {
     namespace = "com.example.reduce_smoking_app"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -41,4 +42,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }


### PR DESCRIPTION
## Summary
- fix NDK version to 27.0.12077973
- enable Java 8 desugaring and add desugar JDK libs dependency

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `gradle app:assembleDebug` *(fails: /workspace/reduce_smoking_app/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_688fcb702030833197a6b067282b6204