### PR TITLE
chore(android): target Java 11 and update NDK

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
     ndkVersion = "27.0.12077973"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
         isCoreLibraryDesugaringEnabled = true
     }
 


### PR DESCRIPTION
## Summary
- use Java 11 for Android compilation and enable desugaring
- pin Android NDK 27.0.12077973 for native builds

## Testing
- `flutter build apk --debug` *(fails: Gradle build daemon disappeared unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_688fce5662388331987a019c2e83bad9