### PR TITLE
Add Firebase initialization and configuration

### DIFF
--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,26 @@
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
+
+/// Default [FirebaseOptions] for the app.
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      default:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions are not configured for this platform.',
+        );
+    }
+  }
+
+  // TODO: Replace the placeholder values below with the actual values
+  // from android/app/google-services.json.
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'TODO: apiKey',
+    appId: 'TODO: appId',
+    messagingSenderId: 'TODO: messagingSenderId',
+    projectId: 'TODO: projectId',
+    storageBucket: 'TODO: storageBucket',
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
 import 'auth_choice_page.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   runApp(const MyApp());
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   flutter_local_notifications: ^17.1.2
   shared_preferences: ^2.2.3
   timezone: ^0.9.2
+  firebase_core: ^2.25.4
+  firebase_auth: ^4.17.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- set up Firebase initialization in main
- add firebase_core and firebase_auth dependencies
- introduce firebase_options placeholder for future config

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68909f7e31f88331b171752f99208fbc