### PR TITLE
Integrate Firebase services

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+    id("com.google.gms.google-services")
 }
 
 android {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,3 +1,13 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.google.gms:google-services:4.4.2")
+    }
+}
+
 allprojects {
     repositories {
         google()

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,9 +1,15 @@
 import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
-import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
 
 /// Default [FirebaseOptions] for the app.
 class DefaultFirebaseOptions {
   static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      throw UnsupportedError(
+        'DefaultFirebaseOptions are not configured for web.',
+      );
+    }
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
         return android;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,8 +37,9 @@ dependencies:
   flutter_local_notifications: ^17.1.2
   shared_preferences: ^2.2.3
   timezone: ^0.9.2
-  firebase_core: ^2.25.4
-  firebase_auth: ^4.17.5
+  firebase_core: ^3.6.0
+  firebase_auth: ^5.4.0
+  cloud_firestore: ^5.4.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Google Services classpath and plugin for Android build
- upgrade Firebase dependencies and add Cloud Firestore
- provide Firebase configuration options

## Testing
- `flutter pub get` *(fails: The current Dart SDK version is 3.5.0. Because reduce_smoking_app requires SDK version ^3.8.1, version solving failed.)*
- `flutter test` *(fails: The current Dart SDK version is 3.5.0. Because reduce_smoking_app requires SDK version ^3.8.1, version solving failed.)*

------
https://chatgpt.com/codex/tasks/task_e_6890b82ec5c083318aad5aa2e311d745