### PR TITLE
chore(android): bump minSdkVersion to 23

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.example.reduce_smoking_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName


### PR DESCRIPTION
## Summary
- set Android minSdkVersion to 23 in app module

## Testing
- `flutter test` *(fails: command not found)*
- `gradle -p android test` *(fails: /workspace/reduce_smoking_app/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_6890bb6955dc8331b48bf1a81676b861