### PR TITLE
Initialize Firebase and anonymous auth on startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,19 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
-import 'firebase_options.dart';
 import 'home_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
-  final userCredential = await FirebaseAuth.instance.signInAnonymously();
-  // Print the UID of the signed-in user to the console.
-  // ignore: avoid_print
-  print('Signed in anonymously as ${userCredential.user?.uid}');
-  runApp(const MyApp());
+  await Firebase.initializeApp();
+  await FirebaseAuth.instance.signInAnonymously();
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
## Summary
- Initialize Firebase when the app starts and sign in a user anonymously before running the app.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890d2279eb08331af91d28402688166