### PR TITLE
Initialize Firebase before app launch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,13 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
+import 'firebase_options.dart';
 import 'home_page.dart';
 
-void main() async {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
-  await FirebaseAuth.instance.signInAnonymously();
-  runApp(MyApp());
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+    await FirebaseAuth.instance.signInAnonymously();
+  } catch (e, st) {
+    debugPrint('Firebase initialization/sign-in failed: $e');
+    debugPrintStack(stackTrace: st);
+  }
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,8 +37,8 @@ dependencies:
   flutter_local_notifications: ^17.1.2
   shared_preferences: ^2.2.3
   timezone: ^0.9.2
-  firebase_core: ^2.24.2
-  firebase_auth: ^4.15.2
+  firebase_core: ^4.0.0
+  firebase_auth: ^6.0.0
   cloud_firestore: ^5.4.4
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Initialize Firebase using `DefaultFirebaseOptions.currentPlatform` and sign in anonymously before `runApp`, with error logging.
- Update `pubspec.yaml` to the latest `firebase_core` and `firebase_auth` versions.

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter run` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6890d58ef56883318b2d99151363b301