### PR TITLE
Initialize Firebase and anonymous sign-in on startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,15 +7,18 @@ import 'home_page.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
+
   try {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
-    await FirebaseAuth.instance.signInAnonymously();
+    final userCredential = await FirebaseAuth.instance.signInAnonymously();
+    debugPrint("Signed in anonymously: ${userCredential.user?.uid}");
   } catch (e, st) {
-    debugPrint('Firebase initialization/sign-in failed: $e');
+    debugPrint("Error signing in anonymously: $e");
     debugPrintStack(stackTrace: st);
   }
+
   runApp(const MyApp());
 }
 


### PR DESCRIPTION
## Summary
- Initialize Firebase using generated options
- Sign in anonymously on launch and log results

## Testing
- `flutter --version` *(command not found)*
- `dart --version` *(command not found)*
- `apt-get install -y dart` *(package not found)*
- `apt-get install -y flutter` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890df6b2304833194b458c6fa686e61