### PR TITLE
chore: use google-services plugin v4.4.2

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.google.gms.google-services") version "4.4.3" apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }
 
 allprojects {


### PR DESCRIPTION
## Summary
- set Google Services Gradle plugin version to 4.4.2

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install flutter` *(fails: Unable to locate package)*
- `snap install flutter --classic` *(fails: cannot communicate with server)*

------
https://chatgpt.com/codex/tasks/task_e_6891f0ea44788331ac3e89ec6c86426c