### PR TITLE
Add cigarette timer with notifications and daily tracking

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,14 +1,91 @@
 import 'package:flutter/material.dart';
+import 'smoking_scheduler.dart';
 
-/// A simple home page that displays a test message.
-class HomePage extends StatelessWidget {
+/// Home page that either accepts the number of cigarettes per day or displays
+/// the countdown timer with daily statistics.
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
 
   @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  final _controller = TextEditingController();
+  final _scheduler = SmokingScheduler.instance;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    if (_scheduler.cigsPerDay == null) {
+      // Setup form for number of cigarettes per day.
+      return Scaffold(
+        appBar: AppBar(title: const Text('Set Daily Cigarettes')),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextField(
+                controller: _controller,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(
+                  labelText: 'Cigarettes per day',
+                ),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  final value = int.tryParse(_controller.text);
+                  if (value != null && value > 0) {
+                    _scheduler.setCigsPerDay(value);
+                    setState(() {});
+                  }
+                },
+                child: const Text('Start'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Timer display.
+    return Scaffold(
+      appBar: AppBar(title: const Text('Cigarette Timer')),
       body: Center(
-        child: Text('Firebase Anonymous Sign-In Test'),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ValueListenableBuilder<Duration>(
+              valueListenable: _scheduler.remaining,
+              builder: (context, duration, _) {
+                final hours = duration.inHours.toString().padLeft(2, '0');
+                final minutes =
+                    duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+                final seconds =
+                    duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+                return Text('Next cigarette in: '
+                    '$hours:$minutes:$seconds');
+              },
+            ),
+            const SizedBox(height: 24),
+            ValueListenableBuilder<int>(
+              valueListenable: _scheduler.smokedToday,
+              builder: (context, count, _) => Text('Smoked today: $count'),
+            ),
+            const SizedBox(height: 8),
+            ValueListenableBuilder<int>(
+              valueListenable: _scheduler.skippedToday,
+              builder: (context, count, _) => Text('Skipped today: $count'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 import 'firebase_options.dart';
 import 'home_page.dart';
+import 'smoking_scheduler.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -12,6 +13,9 @@ Future<void> main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
   debugPrint('Firebase initialized');
+
+  // Initialise smoking scheduler which sets up timers and notifications.
+  await SmokingScheduler.instance.init();
 
   try {
     final userCredential = await FirebaseAuth.instance.signInAnonymously();

--- a/lib/smoking_scheduler.dart
+++ b/lib/smoking_scheduler.dart
@@ -1,0 +1,186 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+/// Manages cigarette scheduling, timers, notifications, and analytics.
+class SmokingScheduler {
+  SmokingScheduler._internal();
+
+  static final SmokingScheduler instance = SmokingScheduler._internal();
+
+  static const _cigsPerDayKey = 'cigsPerDay';
+  static const _nextCigKey = 'nextCigTimestamp';
+  static const _smokedKey = 'smokedToday';
+  static const _skippedKey = 'skippedToday';
+  static const _dateKey = 'statsDate';
+
+  late SharedPreferences _prefs;
+  final FlutterLocalNotificationsPlugin _notifications =
+      FlutterLocalNotificationsPlugin();
+
+  Timer? _timer;
+
+  /// Remaining time until next cigarette.
+  final ValueNotifier<Duration> remaining =
+      ValueNotifier<Duration>(Duration.zero);
+
+  /// Total cigarettes smoked today.
+  final ValueNotifier<int> smokedToday = ValueNotifier<int>(0);
+
+  /// Total cigarettes skipped today.
+  final ValueNotifier<int> skippedToday = ValueNotifier<int>(0);
+
+  /// Initialise preferences, notification plugin and resume any timers.
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+    tz.initializeTimeZones();
+    await _initNotifications();
+
+    smokedToday.value = _prefs.getInt(_smokedKey) ?? 0;
+    skippedToday.value = _prefs.getInt(_skippedKey) ?? 0;
+
+    _resetIfNewDay();
+
+    if (cigsPerDay != null) {
+      final next = _prefs.getInt(_nextCigKey);
+      if (next != null) {
+        final nextTime =
+            DateTime.fromMillisecondsSinceEpoch(next, isUtc: false);
+        _startCountdown(nextTime);
+      }
+    }
+  }
+
+  /// Number of cigarettes per day selected by the user.
+  int? get cigsPerDay => _prefs.getInt(_cigsPerDayKey);
+
+  /// Interval between cigarettes.
+  Duration get interval => cigsPerDay == null
+      ? Duration.zero
+      : Duration(minutes: (24 * 60 / cigsPerDay!).round());
+
+  Future<void> _initNotifications() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    final darwin = DarwinInitializationSettings(notificationCategories: [
+      DarwinNotificationCategory('cigarette', actions: <DarwinNotificationAction>[
+        const DarwinNotificationAction.plain('smoke', 'Smoke now'),
+        const DarwinNotificationAction.plain('skip', 'Skip'),
+      ])
+    ]);
+    final settings = InitializationSettings(android: android, iOS: darwin);
+    await _notifications.initialize(settings,
+        onDidReceiveNotificationResponse: (NotificationResponse resp) {
+      if (resp.actionId == 'smoke') {
+        onSmokeNow();
+      } else if (resp.actionId == 'skip') {
+        onSkip();
+      }
+    });
+
+    await _notifications
+        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+        ?.requestNotificationsPermission();
+    await _notifications
+        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+        ?.requestPermission();
+    await _notifications
+        .resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(alert: true, badge: true, sound: true);
+  }
+
+  /// Set cigarettes per day and schedule the first cigarette.
+  void setCigsPerDay(int value) {
+    _prefs.setInt(_cigsPerDayKey, value);
+    final next = DateTime.now().add(interval);
+    _prefs.setInt(_nextCigKey, next.millisecondsSinceEpoch);
+    _startCountdown(next);
+    scheduleNotification(next);
+  }
+
+  void _startCountdown(DateTime next) {
+    _timer?.cancel();
+    void tick() {
+      final now = DateTime.now();
+      final diff = next.difference(now);
+      if (diff.isNegative) {
+        remaining.value = Duration.zero;
+      } else {
+        remaining.value = diff;
+      }
+    }
+
+    tick();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) => tick());
+  }
+
+  /// Schedule a local notification at [time].
+  Future<void> scheduleNotification(DateTime time) async {
+    await _notifications.zonedSchedule(
+      0,
+      'Cigarette time',
+      'Time to smoke',
+      tz.TZDateTime.from(time, tz.local),
+      const NotificationDetails(
+        android: AndroidNotificationDetails(
+          'cigarette_channel',
+          'Cigarette schedule',
+          importance: Importance.max,
+          priority: Priority.high,
+          actions: <AndroidNotificationAction>[
+            AndroidNotificationAction('smoke', 'Smoke now'),
+            AndroidNotificationAction('skip', 'Skip'),
+          ],
+        ),
+        iOS: DarwinNotificationDetails(categoryIdentifier: 'cigarette'),
+      ),
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      payload: 'cigarette',
+    );
+  }
+
+  /// User decides to smoke now.
+  void onSmokeNow() {
+    _resetIfNewDay();
+    smokedToday.value += 1;
+    _prefs.setInt(_smokedKey, smokedToday.value);
+
+    final next = DateTime.now().add(interval);
+    _prefs.setInt(_nextCigKey, next.millisecondsSinceEpoch);
+    _startCountdown(next);
+    scheduleNotification(next);
+  }
+
+  /// User decides to skip this cigarette.
+  void onSkip() {
+    _resetIfNewDay();
+    skippedToday.value += 1;
+    _prefs.setInt(_skippedKey, skippedToday.value);
+
+    final next = DateTime.now().add(interval);
+    _prefs.setInt(_nextCigKey, next.millisecondsSinceEpoch);
+    _startCountdown(next);
+    scheduleNotification(next);
+  }
+
+  void _resetIfNewDay() {
+    final today = DateTime.now();
+    final todayStr = _dateString(today);
+    final stored = _prefs.getString(_dateKey);
+    if (stored != todayStr) {
+      smokedToday.value = 0;
+      skippedToday.value = 0;
+      _prefs
+        ..setString(_dateKey, todayStr)
+        ..setInt(_smokedKey, 0)
+        ..setInt(_skippedKey, 0);
+    }
+  }
+
+  String _dateString(DateTime d) => '${d.year}-${d.month}-${d.day}';
+}
+


### PR DESCRIPTION
## Summary
- add `SmokingScheduler` service to persist interval, schedule notifications, and track smoked/skipped counts
- wire scheduler into app startup and timer UI
- show countdown timer with daily smoked and skipped totals

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6891fbdc52708331946eaa6ceea6914f