### PR TITLE
Fix notification permission requests

### DIFF
--- a/lib/smoking_scheduler.dart
+++ b/lib/smoking_scheduler.dart
@@ -64,12 +64,17 @@ class SmokingScheduler {
 
   Future<void> _initNotifications() async {
     const android = AndroidInitializationSettings('@mipmap/ic_launcher');
-    final darwin = DarwinInitializationSettings(notificationCategories: [
-      DarwinNotificationCategory('cigarette', actions: <DarwinNotificationAction>[
-        const DarwinNotificationAction.plain('smoke', 'Smoke now'),
-        const DarwinNotificationAction.plain('skip', 'Skip'),
-      ])
-    ]);
+    final darwin = DarwinInitializationSettings(
+        requestAlertPermission: true,
+        requestBadgePermission: true,
+        requestSoundPermission: true,
+        notificationCategories: [
+          DarwinNotificationCategory('cigarette',
+              actions: <DarwinNotificationAction>[
+            DarwinNotificationAction.plain('smoke', 'Smoke now'),
+            DarwinNotificationAction.plain('skip', 'Skip'),
+          ])
+        ]);
     final settings = InitializationSettings(android: android, iOS: darwin);
     await _notifications.initialize(settings,
         onDidReceiveNotificationResponse: (NotificationResponse resp) {
@@ -83,12 +88,6 @@ class SmokingScheduler {
     await _notifications
         .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
         ?.requestNotificationsPermission();
-    await _notifications
-        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
-        ?.requestPermission();
-    await _notifications
-        .resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>()
-        ?.requestPermissions(alert: true, badge: true, sound: true);
   }
 
   /// Set cigarettes per day and schedule the first cigarette.


### PR DESCRIPTION
## Summary
- fix Android and iOS notification permission requests
- use non-const Darwin notification actions

## Testing
- `dart format lib/smoking_scheduler.dart` *(fails: command not found)*
- `flutter format lib/smoking_scheduler.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6892065f4f6483318fef3e9e27eb64a2