### PR TITLE
feat: show dialog when cigarette timer finishes

### DIFF
--- a/lib/main_page.dart
+++ b/lib/main_page.dart
@@ -13,6 +13,7 @@ class MainPage extends StatefulWidget {
 class _MainPageState extends State<MainPage> {
   final _controller = TextEditingController();
   final _scheduler = SmokingScheduler.instance;
+  bool _dialogShown = false;
 
   @override
   void dispose() {
@@ -91,6 +92,44 @@ class _MainPageState extends State<MainPage> {
                   ValueListenableBuilder<Duration>(
                     valueListenable: _scheduler.remaining,
                     builder: (context, duration, _) {
+                      if (duration == Duration.zero && !_dialogShown) {
+                        _dialogShown = true;
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          showDialog(
+                            context: context,
+                            barrierDismissible: false,
+                            builder: (context) {
+                              return AlertDialog(
+                                title: const Text('Log cigarette'),
+                                actions: [
+                                  TextButton(
+                                    onPressed: () {
+                                      _scheduler.registerSmoked();
+                                      _scheduler.scheduleNext();
+                                      setState(() {
+                                        _dialogShown = false;
+                                      });
+                                      Navigator.of(context).pop();
+                                    },
+                                    child: const Text('✅ Accept'),
+                                  ),
+                                  TextButton(
+                                    onPressed: () {
+                                      _scheduler.registerSkipped();
+                                      _scheduler.scheduleNext();
+                                      setState(() {
+                                        _dialogShown = false;
+                                      });
+                                      Navigator.of(context).pop();
+                                    },
+                                    child: const Text('❌ Skip'),
+                                  ),
+                                ],
+                              );
+                            },
+                          );
+                        });
+                      }
                       final hours =
                           duration.inHours.toString().padLeft(2, '0');
                       final minutes = duration.inMinutes

--- a/lib/smoking_scheduler.dart
+++ b/lib/smoking_scheduler.dart
@@ -142,28 +142,38 @@ class SmokingScheduler {
     );
   }
 
-  /// User decides to smoke now.
-  void onSmokeNow() {
+  /// Record a smoked cigarette.
+  void registerSmoked() {
     _resetIfNewDay();
     smokedToday.value += 1;
     _prefs.setInt(_smokedKey, smokedToday.value);
+  }
 
+  /// Record a skipped cigarette.
+  void registerSkipped() {
+    _resetIfNewDay();
+    skippedToday.value += 1;
+    _prefs.setInt(_skippedKey, skippedToday.value);
+  }
+
+  /// Schedule the next cigarette.
+  void scheduleNext() {
     final next = DateTime.now().add(interval);
     _prefs.setInt(_nextCigKey, next.millisecondsSinceEpoch);
     _startCountdown(next);
     scheduleNotification(next);
   }
 
+  /// User decides to smoke now.
+  void onSmokeNow() {
+    registerSmoked();
+    scheduleNext();
+  }
+
   /// User decides to skip this cigarette.
   void onSkip() {
-    _resetIfNewDay();
-    skippedToday.value += 1;
-    _prefs.setInt(_skippedKey, skippedToday.value);
-
-    final next = DateTime.now().add(interval);
-    _prefs.setInt(_nextCigKey, next.millisecondsSinceEpoch);
-    _startCountdown(next);
-    scheduleNotification(next);
+    registerSkipped();
+    scheduleNext();
   }
 
   void _resetIfNewDay() {


### PR DESCRIPTION
## Summary
- show accept/skip dialog when countdown ends
- support registering smoked/skipped and scheduling next cigarette

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689484132d888331a8e390021f1cf02e