### PR TITLE
fix: pin compile SDK version

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.example.reduce_smoking_app"
-    compileSdk = flutter.compileSdkVersion
+    compileSdk = 33
     ndkVersion = "27.0.12077973"
 
     compileOptions {


### PR DESCRIPTION
## Summary
- specify compileSdk 33 and ensure namespace matches app id

## Testing
- `flutter clean` *(fails: /tmp/flutter/packages/flutter_tools: No such file or directory)*
- `flutter pub get` *(fails: /tmp/flutter/packages/flutter_tools: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68949422e3b0833198b90aa3e8a5c5b3