### PR TITLE
chore(android): update compileSdk to 34

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.example.reduce_smoking_app"
-    compileSdk = 33
+    compileSdk = 34
     ndkVersion = "27.0.12077973"
 
     compileOptions {


### PR DESCRIPTION
## Summary
- set Android compileSdk to 34
- confirm app namespace `com.example.reduce_smoking_app`

## Testing
- `flutter clean`
- `flutter pub get` *(fails: Package flutter_local_notifications:linux references flutter_local_notifications_linux:linux as the default plugin, but the package does not exist or is not a plugin package.)*
- `flutter run` *(fails: Could not find compiler set in environment variable CXX: clang++.)*

------
https://chatgpt.com/codex/tasks/task_e_689497b915388331a3d4f978091d4ba9