### PR TITLE
refactor: update notification permissions

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -352,6 +352,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: 1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.1"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.7"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: 38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: 1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   cloud_firestore: ^6.0.0
   flutter_local_notifications: 13.0.0
   flutter_background_service: ^5.0.1
+  permission_handler: ^12.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- request notification permission via permission_handler
- drop deprecated requestNotificationsPermission call and unused import
- add Android 13 notification dependency configuration

## Testing
- `dart pub get` *(fails: Because reduce_smoking_app depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed.)*
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6894d9482d748331a67ee96ef718b459