### PR TITLE
Properly initialize background service and add Android permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <application
         android:label="reduce_smoking_app"
         android:name="${applicationName}"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'auth_choice_page.dart';
@@ -49,6 +50,9 @@ Future<void> showSmokeNotification() async {
 
 @pragma('vm:entry-point')
 void onStart(ServiceInstance service) async {
+  WidgetsFlutterBinding.ensureInitialized();
+  DartPluginRegistrant.ensureInitialized();
+
   await _initNotifications();
 
   Timer.periodic(const Duration(minutes: 30), (timer) {


### PR DESCRIPTION
## Summary
- Ensure background isolate registers plugins and bindings before running notifications
- Allow running as a foreground service on Android

## Testing
- `flutter test`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_68962bb2553083319156f853afc2409d