### PR TITLE
Add scheduled notification service with Accept/Skip actions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,8 +6,8 @@
     <!-- Android 13+ notifications (you already added it — keep it) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <!-- Optional: reschedule alarms after device reboot -->
-    <!-- <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" /> -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <!-- Optional: if you ever use a Foreground service for long tasks -->
     <!-- <uses-permission android:name="android.permission.WAKE_LOCK" /> -->
@@ -40,6 +40,16 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver"
+                  android:exported="false">
+          <intent-filter>
+            <action android:name="android.intent.action.BOOT_COMPLETED"/>
+            <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+          </intent-filter>
+        </receiver>
+
+        <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"
+                  android:exported="false"/>
     </application>
 
     <!-- Package visibility for Process Text plugin -->

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,25 +10,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'firebase_options.dart';
 
 // Local notifications
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-
-// App logic
+import 'notification_service.dart';
 import 'smoking_scheduler.dart';
 
-/// Expose plugin so other files (مثل main_page.dart) هم ازش استفاده کنند.
-final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
-FlutterLocalNotificationsPlugin();
-
-Future<void> _initLocalNotifications() async {
-  const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
-  const initSettings = InitializationSettings(android: androidInit);
-  await flutterLocalNotificationsPlugin.initialize(initSettings);
-
-  final androidImpl =
-  flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
-      AndroidFlutterLocalNotificationsPlugin>();
-  await androidImpl?.requestNotificationsPermission(); // ← این درست است
-}
 
 Future<void> _initFirebaseAndUser() async {
   await Firebase.initializeApp(
@@ -65,8 +49,7 @@ Future<void> _initSmokingScheduler() async {
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
-  await _initLocalNotifications();
+  await NotificationService.instance.init();
   await _initFirebaseAndUser();
   await _initSmokingScheduler();
 

--- a/lib/main_page.dart
+++ b/lib/main_page.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_local_notifications/flutter_local_notifications.dart' as fln;
-
+import 'notification_service.dart';
 import 'smoking_scheduler.dart';
-import 'main.dart'; // assumes you expose: flutterLocalNotificationsPlugin
 
 /// Main page that either accepts the number of cigarettes per day
 /// or displays the countdown timer with daily stats.
@@ -25,22 +23,7 @@ class _MainPageState extends State<MainPage> {
   }
 
   Future<void> _showReminderNotification() async {
-    final android = fln.AndroidNotificationDetails(
-      'smoke_channel',
-      'Smoke Reminder',
-      channelDescription: 'Reminders for the smoking schedule',
-      importance: fln.Importance.max,
-      priority: fln.Priority.high,
-    );
-
-    final details = fln.NotificationDetails(android: android);
-
-    await flutterLocalNotificationsPlugin.show(
-      0,
-      'Time to smoke',
-      'Do you want to smoke this cigarette?',
-      details,
-    );
+    await NotificationService.instance.scheduleCigarette(DateTime.now(), id: 999);
   }
 
   Widget _buildBottomNav() {

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/timezone.dart' as tz;
+import 'package:timezone/data/latest.dart' as tzdata;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/foundation.dart';
+
+class NotificationService {
+  NotificationService._();
+  static final NotificationService instance = NotificationService._();
+  final FlutterLocalNotificationsPlugin _fln = FlutterLocalNotificationsPlugin();
+
+  static const String channelId = 'smoke_schedule';
+  static const String channelName = 'Smoking Schedule';
+  static const String actionAccept = 'ACCEPT_CIG';
+  static const String actionSkip = 'SKIP_CIG';
+
+  Future<void> init() async {
+    tzdata.initializeTimeZones();
+
+    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosInit = DarwinInitializationSettings();
+    const init = InitializationSettings(android: androidInit, iOS: iosInit);
+
+    await _fln.initialize(
+      init,
+      onDidReceiveNotificationResponse: _onForegroundAction,
+      onDidReceiveBackgroundNotificationResponse: NotificationService.onBackgroundAction,
+    );
+
+    final android = _fln.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>();
+    if (android != null) {
+      await android.requestNotificationsPermission();
+      await android.requestExactAlarmsPermission();
+    }
+  }
+
+  void _onForegroundAction(NotificationResponse r) {
+    _handleAction(r.actionId);
+  }
+
+  @pragma('vm:entry-point')
+  static void onBackgroundAction(NotificationResponse r) {
+    NotificationService.instance._handleAction(r.actionId);
+  }
+
+  Future<void> _handleAction(String? actionId) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (actionId == actionAccept) {
+      final n = prefs.getInt('smoked_today') ?? 0;
+      await prefs.setInt('smoked_today', n + 1);
+      // TODO: optionally reschedule here based on adaptive logic
+    } else if (actionId == actionSkip) {
+      final n = prefs.getInt('skipped_today') ?? 0;
+      await prefs.setInt('skipped_today', n + 1);
+      // TODO: increase gap and reschedule if needed
+    }
+  }
+
+  AndroidNotificationDetails _androidDetails() {
+    return const AndroidNotificationDetails(
+      channelId,
+      channelName,
+      importance: Importance.max,
+      priority: Priority.high,
+      category: AndroidNotificationCategory.reminder,
+      actions: <AndroidNotificationAction>[
+        AndroidNotificationAction(actionAccept, 'Accept',
+            showsUserInterface: false, cancelNotification: true),
+        AndroidNotificationAction(actionSkip, 'Skip',
+            showsUserInterface: false, cancelNotification: true),
+      ],
+    );
+  }
+
+  Future<void> scheduleCigarette(DateTime localTime, {required int id}) async {
+    final details = NotificationDetails(android: _androidDetails());
+    await _fln.zonedSchedule(
+      id,
+      'Time to smoke',
+      'Do you want to smoke this cigarette?',
+      tz.TZDateTime.from(localTime, tz.local),
+      details,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: null,
+      payload: 'cigarette',
+    );
+  }
+
+  Future<void> cancel(int id) => _fln.cancel(id);
+  Future<void> cancelAll() => _fln.cancelAll();
+}

--- a/lib/smoking_scheduler.dart
+++ b/lib/smoking_scheduler.dart
@@ -4,6 +4,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
+import 'notification_service.dart';
 
 /// Manages cigarette scheduling, timers, notifications, and analytics.
 class SmokingScheduler {
@@ -191,5 +192,23 @@ class SmokingScheduler {
   }
 
   String _dateString(DateTime d) => '${d.year}-${d.month}-${d.day}';
+
+  Future<void> scheduleDay({
+    required DateTime startLocal,
+    required int cigsPerDay,
+    required int gapMinutes,
+  }) async {
+    await NotificationService.instance.cancelAll();
+
+    for (int i = 0; i < cigsPerDay; i++) {
+      final t = startLocal.add(Duration(minutes: gapMinutes * i));
+      await NotificationService.instance.scheduleCigarette(t, id: 1000 + i);
+    }
+
+    // reset today counters
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('smoked_today', 0);
+    await prefs.setInt('skipped_today', 0);
+  }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  flutter_local_notifications: ^17.1.2
+  flutter_local_notifications: ^17.2.1
   shared_preferences: ^2.2.3
   timezone: ^0.9.2
   firebase_core: ^4.0.0


### PR DESCRIPTION
## Summary
- upgrade `flutter_local_notifications` and wire up a dedicated `NotificationService`
- schedule cigarette reminders with foreground/background Accept/Skip actions
- add `scheduleDay` helper for planning a full day of notifications and reset counters

## Testing
- `flutter pub get` *(fails: command not found)*
- `sudo apt-get install -y flutter` *(fails: unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897125600088331a18833b5d1d7acdd