### PR TITLE
Android 13: add RECEIVER_NOT_EXPORTED flag for in-app broadcast

### DIFF
--- a/android/app/src/main/kotlin/com/example/reduce_smoking_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/reduce_smoking_app/MainActivity.kt
@@ -83,7 +83,11 @@ class MainActivity : FlutterActivity() {
                 }
             }
         }
-        registerReceiver(countsReceiver, IntentFilter(ActionReceiver.ACTION_COUNTS_CHANGED))
+        registerReceiver(
+            countsReceiver,
+            IntentFilter(com.example.reduce_smoking_app.notifications.ActionReceiver.ACTION_COUNTS_CHANGED),
+            Context.RECEIVER_NOT_EXPORTED
+        )
     }
 
     override fun onDestroy() {

--- a/lib/main_page.dart
+++ b/lib/main_page.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'notification_service.dart';
 import 'smoking_scheduler.dart';
 
@@ -16,6 +17,26 @@ class _MainPageState extends State<MainPage> {
   final _controller = TextEditingController();
   final _scheduler = SmokingScheduler.instance;
   bool _dialogShown = false;
+
+  static const _channel = MethodChannel('smoking.native');
+
+  @override
+  void initState() {
+    super.initState();
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'onCountsChanged') {
+        final data = Map<String, dynamic>.from(call.arguments);
+        setState(() {
+          _scheduler.smokedToday.value =
+              (data['smoked_today'] as int?) ?? 0;
+          _scheduler.skippedToday.value =
+              (data['skipped_today'] as int?) ?? 0;
+        });
+        return true;
+      }
+      return null;
+    });
+  }
 
   @override
   void dispose() {


### PR DESCRIPTION
## Summary
- Register counts broadcast receiver with `RECEIVER_NOT_EXPORTED` to satisfy Android 13 requirements and keep the broadcast internal.
- Hook Flutter `MainPage` into the `smoking.native` channel to update counters when native counts change.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689860f0b5bc833194d853c1962fc415